### PR TITLE
Use DB instead of local storage for maintenance

### DIFF
--- a/app/api/maintenance/route.ts
+++ b/app/api/maintenance/route.ts
@@ -1,0 +1,79 @@
+import { NextResponse } from "next/server"
+import pool from "@/lib/db"
+
+export async function GET() {
+  try {
+    const [settingsRows]: any = await pool.query(
+      `SELECT id, price, due_day, late_fee, bank_name, account_holder, clabe, updated_at, updated_by FROM maintenance_settings ORDER BY id DESC LIMIT 1`
+    )
+    const settings = settingsRows[0] || null
+    const [historyRows]: any = await pool.query(
+      `SELECT id, price, effective_date, created_by, created_at, notes FROM maintenance_price_history ORDER BY effective_date DESC`
+    )
+    return NextResponse.json({ success: true, settings, history: historyRows })
+  } catch (err) {
+    console.error(err)
+    return NextResponse.json(
+      { success: false, message: "Server error" },
+      { status: 500 }
+    )
+  }
+}
+
+export async function PUT(req: Request) {
+  try {
+    const body = await req.json()
+    const {
+      price,
+      dueDay,
+      lateFee,
+      bankName,
+      accountHolder,
+      clabe,
+      updatedBy,
+      notes,
+    } = body
+
+    if (
+      price === undefined &&
+      dueDay === undefined &&
+      lateFee === undefined &&
+      bankName === undefined &&
+      accountHolder === undefined &&
+      clabe === undefined
+    ) {
+      return NextResponse.json(
+        { success: false, message: "No data provided" },
+        { status: 400 }
+      )
+    }
+
+    await pool.query(
+      `UPDATE maintenance_settings SET price = COALESCE(?, price), due_day = COALESCE(?, due_day), late_fee = COALESCE(?, late_fee), bank_name = COALESCE(?, bank_name), account_holder = COALESCE(?, account_holder), clabe = COALESCE(?, clabe), updated_at = NOW(), updated_by = ? WHERE id = 1`,
+      [
+        price,
+        dueDay,
+        lateFee,
+        bankName,
+        accountHolder,
+        clabe,
+        updatedBy,
+      ]
+    )
+
+    if (price !== undefined) {
+      await pool.query(
+        `INSERT INTO maintenance_price_history (price, effective_date, created_by, created_at, notes) VALUES (?, NOW(), ?, NOW(), ?)`,
+        [price, updatedBy, notes || null]
+      )
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    console.error(err)
+    return NextResponse.json(
+      { success: false, message: "Server error" },
+      { status: 500 }
+    )
+  }
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,5 +1,4 @@
 import { create } from "zustand"
-import { persist } from "zustand/middleware"
 
 export type UserRole = "admin" | "resident" | "vigilante" | "mantenimiento"
 
@@ -50,9 +49,7 @@ interface AuthState {
   resetStore: () => void
 }
 
-export const useAuthStore = create<AuthState>()(
-  persist(
-    (set, get) => ({
+export const useAuthStore = create<AuthState>()((set, get) => ({
       user: null,
       token: null,
       isAuthenticated: false,
@@ -173,21 +170,4 @@ export const useAuthStore = create<AuthState>()(
           users: [],
         })
       },
-    }),
-    {
-      name: "arcos-auth-storage",
-      partialize: (state) =>
-        state.rememberMe
-          ? {
-              user: state.user,
-              token: state.token,
-              isAuthenticated: state.isAuthenticated,
-              isAdmin: state.isAdmin,
-              isVigilante: state.isVigilante,
-              isMantenimiento: state.isMantenimiento,
-              rememberMe: state.rememberMe,
-            }
-          : { rememberMe: state.rememberMe },
-    },
-  ),
-)
+    }))

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -1,5 +1,4 @@
 import { create } from "zustand"
-import { persist } from "zustand/middleware"
 import { v4 as uuidv4 } from "uuid"
 
 export interface PetReport {
@@ -145,9 +144,7 @@ interface AppState {
 }
 
 // Actualizar el estado inicial y las funciones
-export const useAppStore = create<AppState>()(
-  persist(
-    (set, get) => ({
+export const useAppStore = create<AppState>()((set, get) => ({
       petReports: [],
       notices: [],
       // Precio inicial de mantenimiento
@@ -609,8 +606,4 @@ export const useAppStore = create<AppState>()(
           adminTasks: state.adminTasks.filter((task) => task.id !== id),
         })),
     }),
-    {
-      name: "arcos-app-storage",
-    },
-  ),
-)
+))


### PR DESCRIPTION
## Summary
- drop zustand `persist` usage
- create `maintenance` API endpoint to read/update settings in MySQL
- fetch maintenance settings from API in admin page
- update forms to save via API

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ff635a2848321b917e90580349a63